### PR TITLE
initial fixes on balancing issues

### DIFF
--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -3993,20 +3993,20 @@ pick_next_task(struct rq *rq, struct task_struct *prev, struct rq_flags *rf)
 restart:
 	*/
 
-//#ifdef CONFIG_SMP
-//	/*
-//	 * We must do the balancing pass before put_next_task(), such
-//	 * that when we release the rq->lock the task is in the same
-//	 * state as before we took rq->lock.
-//	 *
-//	 * We can terminate the balance pass as soon as we know there is
-//	 * a runnable task of @class priority or higher.
-//	 */
-//	for_class_range(class, prev->sched_class, &idle_sched_class) {
-//		if (class->balance(rq, prev, rf))
-//			break;
-//	}
-//#endif
+#ifdef CONFIG_SMP
+	/*
+	 * We must do the balancing pass before put_next_task(), such
+	 * that when we release the rq->lock the task is in the same
+	 * state as before we took rq->lock.
+	 *
+	 * We can terminate the balance pass as soon as we know there is
+	 * a runnable task of @class priority or higher.
+	 */
+	for_class_range(class, prev->sched_class, &idle_sched_class) {
+		if (class->balance(rq, prev, rf))
+			break;
+	}
+#endif
 
 	put_prev_task(rq, prev);
 


### PR DESCRIPTION
Leo's initial fixes on balancing issues:

I tried to add the check is_realtime(rq->curr) in pick_next_task_litmus(), and it seemed to work properly with no uses of prev in the function. I'll definitely run more extensive test cases to complete the updates.